### PR TITLE
[0.2.0] - If the run failed, get out of the way

### DIFF
--- a/chef-handler-sensu.gemspec
+++ b/chef-handler-sensu.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'chef-handler-sensu'
-  s.version = '0.1.1'
+  s.version = '0.2.0'
   s.author = 'Simple Finance'
   s.email = 'ops@simple.com'
   s.homepage = 'http://github.com/SimpleFinance/chef-handler-sensu'

--- a/lib/chef-handler-sensu.rb
+++ b/lib/chef-handler-sensu.rb
@@ -39,6 +39,7 @@ class SensuCleaner < Chef::Handler
   end
 
   def report
+    if run_status.fail? then return end
     checks = all_checks
     Dir[::File.join(node[:sensu][:directory], 'conf.d', 'checks', '*')].reject do |file|
       checks.include?(::File.basename(file, '.json'))

--- a/lib/chef-handler-sensu.rb
+++ b/lib/chef-handler-sensu.rb
@@ -39,7 +39,7 @@ class SensuCleaner < Chef::Handler
   end
 
   def report
-    if run_status.fail? then return end
+    if run_status.failed? then return end
     checks = all_checks
     Dir[::File.join(node[:sensu][:directory], 'conf.d', 'checks', '*')].reject do |file|
       checks.include?(::File.basename(file, '.json'))


### PR DESCRIPTION
This fixes a bug wherein Chef fails while generating Sensu checks, and because some number of checks haven't become resources yet, this handler removes them from disk. This isn't the behavior we want.
